### PR TITLE
Remove unnecessary registration condition and update FranceConnect signin message

### DIFF
--- a/theme/df/login/login.ftl
+++ b/theme/df/login/login.ftl
@@ -55,7 +55,7 @@
             <div class="fr-col-lg-6 fr-col-12 bg-white">
                 <div class="fr-mt-2w align-end">
 
-                    <#if realm.password && realm.registrationAllowed && !registrationDisabled?? && client.getAttribute('use.keycloak.registration')?has_content && client.getAttribute('use.keycloak.registration') == 'true' >
+                    <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
                         <a href="${url.registrationUrl}" class="fr-tag">
                             ${ msg("login.signup-link") }
                         </a>

--- a/theme/df/login/messages/messages_en.properties
+++ b/theme/df/login/messages/messages_en.properties
@@ -428,9 +428,11 @@ login.password=Password :
 signup.title=Join DossierFacile
 signup.connexion-france-connect-title=Connexion FranceConnect
 signup.connexion-france-connect-title=FranceConnect Login
-signup.connexion-france-connect-text=If you are making a DossierFacile for your child,
-signup.connexion-france-connect-text2=create an account in their name
-signup.connexion-france-connect-text3=or use their FranceConnect account. The DossierFacile must be in your child's name.
+signup.connexion-france-connect-text=The DossierFacile must be
+signup.connexion-france-connect-text2=in the name of the future tenant.
+signup.connexion-france-connect-text3=If you are creating a file for your child,
+signup.connexion-france-connect-text4=do not identify yourself
+signup.connexion-france-connect-text5=with your FranceConnect account.
 
 
 

--- a/theme/df/login/messages/messages_fr.properties
+++ b/theme/df/login/messages/messages_fr.properties
@@ -299,9 +299,11 @@ login.password=Votre mot de passe :
 
 signup.title=Rejoindre DossierFacile
 signup.connexion-france-connect-title=Connexion FranceConnect
-signup.connexion-france-connect-text=Le DossierFacile doit \u00eatre au nom du futur locataire. Si vous faites un dossier pour votre enfant, utilisez
-signup.connexion-france-connect-text2=son compte FranceConnect
-signup.connexion-france-connect-text3=plut\u00f4t que le v\u00f4tre
+signup.connexion-france-connect-text=Le DossierFacile doit \u00eatre
+signup.connexion-france-connect-text2=au nom du futur locataire.
+signup.connexion-france-connect-text3=Si vous cr\u00e9ez un dossier pour votre enfant,
+signup.connexion-france-connect-text4=ne vous identifiez pas
+signup.connexion-france-connect-text5=avec votre compte FranceConnect.
 
 header.signup=Se connecter
 header.owner=Espace propri\u00e9taire

--- a/theme/df/login/register.ftl
+++ b/theme/df/login/register.ftl
@@ -53,7 +53,7 @@
             </div>
             <div class="fr-col-lg-6 fr-col-12 bg-white">
                 <div class="fr-mt-2w align-end">
-                    <#if realm.password && realm.registrationAllowed && !registrationDisabled?? && client.getAttribute('use.keycloak.registration')?has_content && client.getAttribute('use.keycloak.registration') == 'true' >
+                    <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
                         <a href="${url.loginUrl}" class="fr-tag">
                             ${ msg("login.signin-link") }
                         </a>

--- a/theme/df/login/register.ftl
+++ b/theme/df/login/register.ftl
@@ -69,7 +69,7 @@
                     <#if realm.password && social.providers??>
                         <div class="fr-alert fr-alert--info">
                             <h2 class="fr-alert__title">${ msg("signup.connexion-france-connect-title") }</h2>
-                            <p>${ msg("signup.connexion-france-connect-text") } <strong>${ msg("signup.connexion-france-connect-text2") }</strong> ${ msg("signup.connexion-france-connect-text3") }</p>
+                            <p>${ msg("signup.connexion-france-connect-text") } <strong>${ msg("signup.connexion-france-connect-text2") }</strong> ${ msg("signup.connexion-france-connect-text3") } <strong>${ msg("signup.connexion-france-connect-text4") }</strong> ${ msg("signup.connexion-france-connect-text5") }</p>
                         </div>
                         <div class="text-center">
                             <div class="fr-mt-2w fr-mb-2w small-text">


### PR DESCRIPTION
Simplify condition for registration link

See original condition in Keycloak last base theme (line 83):
- https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/login/login.ftl

Fix:
- https://www.notion.so/dossierfacile/Pas-de-redirection-vers-consentement-en-cas-de-cr-ation-de-compte-via-login-mdp-dfconnect-17b6cd6935b98059b184d7247dfdf16c?pvs=4